### PR TITLE
fix: refactor cache key

### DIFF
--- a/src/services/helper.service.ts
+++ b/src/services/helper.service.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import apm from '../apm';
-// import { CalculateDuration } from '@frmscoe/frms-coe-lib/lib/helpers/calculatePrcg';
 import { databaseManager, loggerService } from '..';
 import { type NetworkMap, type Pacs002 } from '@frmscoe/frms-coe-lib/lib/interfaces';
 import { type TypologyResult } from '@frmscoe/frms-coe-lib/lib/interfaces/processor-files/TypologyResult';
@@ -12,7 +11,6 @@ export const handleTypologies = async (
   typologyResult: TypologyResult,
 ): Promise<{ typologyResult: TypologyResult[]; review: boolean }> => {
   let span;
-  //  const startTime = process.hrtime.bigint();
   const functionName = 'handleTypologies()';
   try {
     const typologies = networkMap.messages[0].typologies;
@@ -20,7 +18,8 @@ export const handleTypologies = async (
     const cacheKey = `TADP_${transactionID}_TP`;
     const jtypologyCount = await databaseManager.addOneGetCount(cacheKey, { typologyResult: { ...typologyResult } });
 
-    // check if all results for this Channel is found
+    // Check if all typologyRules have been stored
+    // Compare with configured network map's typologies
     if (jtypologyCount && jtypologyCount < typologies.length) {
       return {
         review: false,
@@ -28,7 +27,7 @@ export const handleTypologies = async (
       };
     }
 
-    // else means we have all results for Channel, so lets evaluate result
+    // else means we have all results for Typologies, so lets evaluate result
     const jtypologyResults = await databaseManager.getMemberValues(cacheKey);
     const typologyResults: TypologyResult[] = jtypologyResults.map(
       (jtypologyResult: { typologyResult: TypologyResult }) => jtypologyResult.typologyResult,

--- a/src/services/helper.service.ts
+++ b/src/services/helper.service.ts
@@ -18,7 +18,7 @@ export const handleTypologies = async (
     const cacheKey = `TADP_${transactionID}_TP`;
     const jtypologyCount = await databaseManager.addOneGetCount(cacheKey, { typologyResult: { ...typologyResult } });
 
-    // Check if all typologyRules have been stored
+    // Check if all typologyResults have been stored
     // Compare with configured network map's typologies
     if (jtypologyCount && jtypologyCount < typologies.length) {
       return {

--- a/src/services/helper.service.ts
+++ b/src/services/helper.service.ts
@@ -15,9 +15,9 @@ export const handleTypologies = async (
   //  const startTime = process.hrtime.bigint();
   const functionName = 'handleTypologies()';
   try {
-    const typologies = networkMap.messages[0].typologies.filter((t) => t.id === typologyResult.id && t.cfg === typologyResult.cfg);
+    const typologies = networkMap.messages[0].typologies;
     const transactionID = transaction.FIToFIPmtSts.GrpHdr.MsgId;
-    const cacheKey = `TADP_${transactionID}_${typologyResult.id}_${typologyResult.cfg}`;
+    const cacheKey = `TADP_${transactionID}_TP`;
     const jtypologyCount = await databaseManager.addOneGetCount(cacheKey, { typologyResult: { ...typologyResult } });
 
     // check if all results for this Channel is found


### PR DESCRIPTION
BUG FIX PR

Trait: No report was returning if the networkmap had more than 1 typologies configured

Fix: Refactor the key used to cache so other typologies are stored with other typologies' transaction 

Cause: The Redis key for storing the typologies was always unique, causing the return of the count of already stored data to always return 1

![image](https://github.com/frmscoe/transaction-aggregation-decisioning-processor/assets/131665740/f3b530af-ff68-44fb-b91c-3dd0e56e9ebd)
